### PR TITLE
Add unit tests

### DIFF
--- a/tests/test_csvio.py
+++ b/tests/test_csvio.py
@@ -1,0 +1,82 @@
+import types, sys
+def transl(s, lang="sr"):
+    mapping = {"Н":"N","н":"n","и":"i","к":"k","о":"o","л":"l","а":"a","ћ":"c","č":"c"}
+    return "".join(mapping.get(ch,ch) for ch in s)
+cyr=types.SimpleNamespace(to_latin=transl)
+sys.modules.setdefault("cyrtranslit", cyr)
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import csvio
+import os
+
+
+def test_clean_name():
+    assert csvio.clean_name('Никола Николић') == 'nikola nikolic'
+
+
+def test_load_debater_elo(tmp_path):
+    file = tmp_path / 'elo.csv'
+    file.write_text('John_Doe 1200 3\nJane_Smith 1100 4\n', encoding='utf-8')
+    result = csvio.load_debater_elo(str(file))
+    assert result['john_doe'] == (1200.0, 3)
+    assert result['jane_smith'] == (1100.0, 4)
+
+
+def test_load_debater_elo_alt(tmp_path):
+    file = tmp_path / 'elo_alt.csv'
+    file.write_text('John Doe 1200 3\nJane Smith 1100 4\n', encoding='utf-8')
+    result = csvio.load_debater_elo(str(file), alt_mod=True)
+    assert result['john doe'] == (1200.0, 3)
+    assert result['jane smith'] == (1100.0, 4)
+
+
+def test_load_teams_participants(tmp_path):
+    file = tmp_path / 'teams.csv'
+    row = '\t'.join(['1', 'John Doe', 'TeamA'] + ['x'] * 8) + '\n'
+    file.write_text('header\n' + row, encoding='utf-8')
+    result = csvio.load_teams_participants(str(file), speaker_csv_mode=True)
+    assert result['john doe'] == 'TeamA'
+
+
+def test_load_team_ranks(tmp_path):
+    file = tmp_path / 'ranks.csv'
+    file.write_text('header\nTeamA\tCollege\t1st\n', encoding='utf-8')
+    result = csvio.load_team_ranks(str(file))
+    assert result['TeamA'] == 1
+
+
+def test_convert_rank():
+    assert csvio.convert_rank('3rd') == 3
+
+
+def test_load_debates(tmp_path):
+    file = tmp_path / 'debates.csv'
+    file.write_text('header\n1\tTeamA\tTeamB\tTeamC\tTeamD\n', encoding='utf-8')
+    result = csvio.load_debates(str(file))
+    assert {'TeamA', 'TeamB', 'TeamC', 'TeamD'} in result
+
+
+def test_export_debater_elo(tmp_path):
+    data = {'john': (1000.0, 1)}
+    file = tmp_path / 'out.csv'
+    csvio.export_debater_elo(data, str(file))
+    content = file.read_text(encoding='utf-8').strip()
+    assert content == 'john 1000.0 1'
+
+
+def test_uvezi_spikere(tmp_path):
+    file = tmp_path / 'spk.csv'
+    row = ['1', 'John Doe', 'x', 'TeamA'] + ['70'] * 5 + ['75']
+    file.write_text('header\n' + '\t'.join(row) + '\n', encoding='utf-8')
+    result = csvio.uvezi_spikere(str(file), no_of_rounds=5)
+    assert result['john doe'][0] == 'TeamA'
+    assert result['john doe'][1] == [70] * 5
+    assert result['john doe'][2] == 75.0
+
+
+def test_add_debaters(tmp_path):
+    data = {}
+    file = tmp_path / 'add.csv'
+    file.write_text('header\n1\tJohn Doe\tTeamA\n', encoding='utf-8')
+    csvio.add_debaters(data, str(file))
+    assert 'john doe' in data
+    assert data['john doe'] == (1000, 0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,80 @@
+import sys
+import types
+pyperclip = types.SimpleNamespace(paste=lambda: "", copy=lambda x: None)
+sys.modules.setdefault("pyperclip", pyperclip)
+import types, sys
+cyr=types.SimpleNamespace(to_latin=lambda s,lang:s)
+service_mod=types.ModuleType("service")
+service_mod.Service=object
+wcm_mod=types.ModuleType("wcm")
+wcm_mod.ChromeDriverManager=object
+selenium_mod=types.ModuleType("selenium")
+webdriver_mod=types.ModuleType("webdriver")
+webdriver_mod.Chrome=lambda *a,**k: None
+sys.modules.setdefault("cyrtranslit", cyr)
+sys.modules.setdefault("selenium", selenium_mod)
+csvio_stub = types.SimpleNamespace(load_debater_elo=lambda f:{}, add_debaters=lambda d,f:None, load_teams_participants=lambda f,no_of_rounds=5:{}, uvezi_spikere=lambda f,no_of_rounds=5:{}, load_team_ranks=lambda f,alt_instit=True:{}, load_debates=lambda f:[], export_debater_elo=lambda data,file:None); sys.modules["csvio"] = csvio_stub
+webio_stub = types.SimpleNamespace(download_whole_tournament=lambda url,n:None); sys.modules["webio"] = webio_stub
+sys.modules.setdefault("selenium.webdriver", webdriver_mod)
+sys.modules.setdefault("selenium.webdriver.chrome", types.ModuleType("chrome"))
+sys.modules.setdefault("selenium.webdriver.chrome.service", service_mod)
+sys.modules.setdefault("webdriver_manager.chrome", wcm_mod)
+import sys, os; sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import main
+import csvio
+
+
+def test_generate_pairs_teams():
+    ranks = {'A':1, 'B':2, 'C':3, 'D':4}
+    debates = [{'A','B','C','D'}]
+    result = main.generate_pairs_teams(ranks, debates)
+    assert ('A','B') in result
+    assert ('A','C') in result
+    assert ('C','D') in result
+
+
+def test_generate_pairs_debaters():
+    pairs = [('A','B')]
+    speakers = {'alice':'A','bob':'B'}
+    result = main.generate_pairs_debaters(pairs, speakers)
+    # expecting four combinations
+    assert len(result) == 4
+
+
+def test_calculate_k_factor():
+    assert main.calculate_k_factor((1600,3)) == 60
+
+
+def test_find_partner():
+    speakers = {'alice':('Team', [70],70), 'bob':('Team',[60],60)}
+    assert main.find_partner('alice', speakers) == 'bob'
+
+
+def test_apply_speaker_modifier():
+    speakers = {'alice':('Team',[70],70),'bob':('Team',[60],60)}
+    assert main.apply_speaker_modifier('alice', speakers, True, 1) > 1
+
+
+def test_calculate_elo():
+    pairs = [('alice','bob')]
+    elo = {'alice':(1000,0),'bob':(1000,0)}
+    spk = {'alice':('A',[70],70),'bob':('B',[60],60)}
+    result = main.calculate_elo(pairs, elo, spk, 1)
+    assert result['alice'][0] != 1000
+
+
+def test_enter_tournament(monkeypatch):
+    calls = []
+    monkeypatch.setattr(main.webio, 'download_whole_tournament', lambda u,r: calls.append('web'))
+    monkeypatch.setattr(main.csvio, 'load_debater_elo', lambda f: {})
+    monkeypatch.setattr(main.csvio, 'add_debaters', lambda e,f: calls.append('add'))
+    monkeypatch.setattr(main.csvio, 'load_teams_participants', lambda f,no_of_rounds: {'a':'A'})
+    monkeypatch.setattr(main.csvio, 'uvezi_spikere', lambda f,no_of_rounds: {'a':('A',[70],70)})
+    monkeypatch.setattr(main.csvio, 'load_team_ranks', lambda f,alt_instit=True: {'A':1,'B':2})
+    monkeypatch.setattr(main.csvio, 'load_debates', lambda f: [{'A','B'}])
+    monkeypatch.setattr(main, 'generate_pairs_teams', lambda ranks,debates: [('A','B')])
+    monkeypatch.setattr(main, 'generate_pairs_debaters', lambda pairs,st: [('a','b')])
+    monkeypatch.setattr(main, 'calculate_elo', lambda pairs,elo,spk,i: {'a':(1000,1)})
+    monkeypatch.setattr(main.csvio, 'export_debater_elo', lambda elo,file: calls.append(file))
+    main.enter_tournament('url',num_of_rounds=1, spk_file='spk.csv', new_elo_file='elo.csv')
+    assert 'web' in calls

--- a/tests/test_webio.py
+++ b/tests/test_webio.py
@@ -1,0 +1,70 @@
+import sys
+import types
+pyperclip = types.SimpleNamespace(paste=lambda: "", copy=lambda x: None)
+sys.modules.setdefault("pyperclip", pyperclip)
+
+# Ensure real webio module is loaded
+sys.modules.pop('webio', None)
+
+selenium = types.ModuleType('selenium')
+webdriver_mod = types.ModuleType('webdriver')
+webdriver_mod.Chrome = lambda *a, **k: None
+chrome_mod = types.ModuleType('chrome')
+service_mod = types.ModuleType('service')
+service_mod.Service = object
+wcm_mod = types.ModuleType('wcm')
+wcm_mod.ChromeDriverManager = object
+sys.modules['selenium'] = selenium
+sys.modules['selenium.webdriver'] = webdriver_mod
+sys.modules['selenium.webdriver.chrome'] = chrome_mod
+sys.modules['selenium.webdriver.chrome.service'] = service_mod
+sys.modules['webdriver_manager.chrome'] = wcm_mod
+
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+import importlib
+webio = importlib.import_module('webio')
+from unittest.mock import MagicMock, patch
+
+
+def test_load_speakers_text():
+    driver = MagicMock()
+    with patch('pyperclip.paste', return_value='csvdata'):
+        result = webio.load_speakers_text(driver, 'http://site')
+    driver.get.assert_called_with('http://site/tab/speaker/')
+    driver.find_element.assert_called()
+    assert result == 'csvdata'
+
+
+def test_load_teams_ranks_text():
+    driver = MagicMock()
+    with patch('pyperclip.paste', return_value='csv'):
+        result = webio.load_teams_ranks_text(driver, 'u', '1')
+    driver.get.assert_called()
+    assert result == 'csv'
+
+
+def test_load_teams_debates_text():
+    driver = MagicMock()
+    with patch('pyperclip.paste', return_value='csv'):
+        result = webio.load_teams_debates_text(driver, 'u', '1')
+    driver.get.assert_called()
+    assert result == 'csv'
+
+
+def test_export_file(tmp_path):
+    file = tmp_path / 'f.txt'
+    webio.export_file(str(file), 'hello')
+    assert file.read_text(encoding='utf-8') == 'hello'
+
+
+def test_download_whole_tournament(monkeypatch):
+    mock_driver = MagicMock()
+    monkeypatch.setattr(webio, 'webdriver', MagicMock(Chrome=MagicMock(return_value=mock_driver)))
+    monkeypatch.setattr(webio, 'load_speakers_text', lambda d,u: 'spk')
+    monkeypatch.setattr(webio, 'load_teams_ranks_text', lambda d,u,r: 'rank')
+    monkeypatch.setattr(webio, 'load_teams_debates_text', lambda d,u,r: 'deb')
+    exports = []
+    monkeypatch.setattr(webio, 'export_file', lambda n,c: exports.append((n,c)))
+    webio.download_whole_tournament('url', br_rundi=1)
+    assert ('tournament_files/speakers.csv', 'spk') in exports


### PR DESCRIPTION
## Summary
- add unit tests covering csvio, webio, and main modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68540451f7988320a00c50b576fa0e25